### PR TITLE
add docker documentation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Before starting the backend you need to install [docker](https://docs.docker.com
 To start our project using docker, you must be shure to have to corresponding .env file
 You can check the `.env.example` file to check the required variables
 
+Then you need to go to the `dockerfile/base` folder to build the base image, here is the [documentation](dockerfiles/base/README.md) of the image for more informations.
+
 When this is done, you can build the backend using this command:
 ```
 docker-compose build backend

--- a/dockerfiles/base/README.md
+++ b/dockerfiles/base/README.md
@@ -1,0 +1,54 @@
+# Ollamy base docker image
+
+---
+
+This image has been made to build all the packages needed by ollamy services.
+
+## How does it work:
+
+- First you need to go to the `base` folder:
+
+```sh
+cd dockerfiles/base
+```
+
+- run the `build.sh` file. Before running it you may need to understand the purpose of this file.
+
+### Build.sh file explanations
+- We copy the .env, package.json and yarn.lock files and store them in a dedicated folder called dockerfiles/base:
+
+```sh
+cp ../../package.json ../../yarn.lock ../../.env .
+```
+
+- We find all the existing folders in **package** excluding the node modules. They will created with the image. Then, we create the image with the given name (here __ollamy-base__):
+
+``` sh
+find ../../packages -type d -name "node_modules" -prune -o -type f
+-name "package.json" -print -exec sh -c 'mkdir -p "packages/$(basename $(dirname "{}"))" && cp "{}" "packages/$(basename $(dirname "{}"))/package.json"' \;
+docker build -t "$IMAGE_NAME" . --network=host || exit $?
+```
+
+- Finally, we remove the files that we copied previously to keep the folder clean
+
+```sh
+rm -rf packages package.json yarn.lock .env
+```
+
+
+
+### Use the build file
+
+- Now, you can run the scipt using this command:
+
+```sh
+bash build.sh
+```
+
+> :warning: In case of **Permission Denied** error messages, you can run it using sudo:
+
+```sh
+sudo bash build.sh
+```
+
+After building the ollamy base image using the build.sh file, we can use it in our services containers.


### PR DESCRIPTION
## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5a2b8e</samp>

This pull request adds documentation and instructions for the new base image in the `dockerfile/base` folder. The base image is a common layer for the ollamy services that provides some dependencies and configurations.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c5a2b8e</samp>

*  Add a new README.md file to the `dockerfile/base` folder with documentation of the base image ([link](https://github.com/Ollamy/Ollamy/pull/51/files?diff=unified&w=0#diff-d309e47fa6fa4fb1fe7352908dc454058def6c5bc0a9661f6c10bc501c33fc9cR1-R54))
*  Update the main README.md file with a new instruction to build and use the base image in the `Build steps` section ([link](https://github.com/Ollamy/Ollamy/pull/51/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15-R16))

## Checklist

**Bureaucracy**

- [x] I set a descriptive title
- [x] I set a proper description, providing enough information to the reviewer
- [x] I considered squashing this PR, if needed
- [x] I set the proper assignee
- [x] I set the proper reviewers