### PR TITLE
Remove Profile and Settings from HomeSidePanel

### DIFF
--- a/packages/service-maker/src/pages/Home/SidePanel/HomeSidePanel.tsx
+++ b/packages/service-maker/src/pages/Home/SidePanel/HomeSidePanel.tsx
@@ -38,24 +38,24 @@ function HomeSidePanel({ currentPage, setCurrentPage }: HomeSidePanelProps) {
                 Home
               </LinkNav>
             </NavigationMenu.Item>
-            <NavigationMenu.Item onClick={() => handleClick('profile')}>
-              <LinkNav
-                active={currentPage === 'profile'}
-                className={'NavigationMenuLink'}
-              >
-                <PersonIcon />
-                Profile
-              </LinkNav>
-            </NavigationMenu.Item>
-            <NavigationMenu.Item onClick={() => handleClick('settings')}>
-              <LinkNav
-                active={currentPage === 'settings'}
-                className={'NavigationMenuLink'}
-              >
-                <GearIcon />
-                Settings
-              </LinkNav>
-            </NavigationMenu.Item>
+            {/* <NavigationMenu.Item onClick={() => handleClick('profile')}> */}
+            {/*   <LinkNav */}
+            {/*     active={currentPage === 'profile'} */}
+            {/*     className={'NavigationMenuLink'} */}
+            {/*   > */}
+            {/*     <PersonIcon /> */}
+            {/*     Profile */}
+            {/*   </LinkNav> */}
+            {/* </NavigationMenu.Item> */}
+            {/* <NavigationMenu.Item onClick={() => handleClick('settings')}> */}
+            {/*   <LinkNav */}
+            {/*     active={currentPage === 'settings'} */}
+            {/*     className={'NavigationMenuLink'} */}
+            {/*   > */}
+            {/*     <GearIcon /> */}
+            {/*     Settings */}
+            {/*   </LinkNav> */}
+            {/* </NavigationMenu.Item> */}
 
             <NavigationMenu.Indicator className={'NavigationMenuIndicator'}>
               <div className={'Arrow'} />

--- a/packages/service-maker/src/pages/Home/SidePanel/HomeSidePanel.tsx
+++ b/packages/service-maker/src/pages/Home/SidePanel/HomeSidePanel.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import 'styles/navigationMenu.css';
 
-import { GearIcon, HomeIcon, PersonIcon } from '@radix-ui/react-icons';
+import { HomeIcon } from '@radix-ui/react-icons';
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
 
 interface HomeSidePanelProps {


### PR DESCRIPTION
Profile and Settings links have been commented out from the HomeSidePanel component. The coresponding `onClick` handlers and icon usages have also been commented out.

## Summary

Please write a summary of your changes. Provide any information that could be
useful to the reviewer.

## Checklist

**Bureaucracy**

- [ ] I set a descriptive title
- [ ] I set a proper description, providing enough information to the reviewer
- [ ] I considered squashing this PR, if needed
- [ ] I set the proper assignee
- [ ] I set the proper reviewers

**Quality Assurance**

- [ ] I tested the behavior of this PR locally and made sure it complies with
  the ticket description
