### PR TITLE
Fix session get bonus question from preloaded data

### DIFF
--- a/packages/service-backend/src/session/session.service.ts
+++ b/packages/service-backend/src/session/session.service.ts
@@ -221,12 +221,7 @@ export class SessionService {
       (question) => question.id === body.questionId,
     );
     const nextQuestion = preloaded_data[indexOfCurrentQuestion + 1] ?? null;
-    const { bonus } = await prisma.question.findUnique({
-      where: { id: session.current_question_id },
-      select: {
-        bonus: true,
-      },
-    });
+    const bonus = preloaded_data[indexOfCurrentQuestion].bonus;
     const isCorrect =
       preloaded_data[indexOfCurrentQuestion].Answer[0].id === body.answer.id ||
       preloaded_data[indexOfCurrentQuestion].Answer[0].data ===


### PR DESCRIPTION
## Summary

Removed the prisma query to get bonus question, use the preloaded data instead to avoid to many database calls

